### PR TITLE
chore: make audio/transcriptions test more flexible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,7 @@ dependencies = [
  "hf-hub",
  "hyper 1.1.0",
  "hyper-util",
+ "levenshtein",
  "once_cell",
  "pin-project",
  "rubato",
@@ -2707,6 +2708,12 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libappindicator"

--- a/crates/edgen_server/Cargo.toml
+++ b/crates/edgen_server/Cargo.toml
@@ -37,3 +37,6 @@ utoipa = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 tower-http = { version = "0.5.1", features = ["cors"] }
 edgen_core = { path = "../edgen_core" }
+
+[dev-dependencies]
+levenshtein = "1.0.5"

--- a/crates/edgen_server/src/lib.rs
+++ b/crates/edgen_server/src/lib.rs
@@ -36,8 +36,6 @@ use edgen_core::whisper::{DecodeSessionError, SessionRunnerError, WhisperError};
 use openai_shim as chat;
 use openai_shim as audio;
 
-#[cfg(test)]
-use levenshtein;
 #[macro_use]
 pub mod misc;
 
@@ -295,6 +293,7 @@ mod tests {
     use axum::Router;
     use axum_test::multipart;
     use axum_test::TestServer;
+    use levenshtein;
     use serde_json::from_str;
 
     fn completion_streaming_request() -> String {

--- a/crates/edgen_server/src/lib.rs
+++ b/crates/edgen_server/src/lib.rs
@@ -439,6 +439,8 @@ mod tests {
     }
 
     #[tokio::test]
+    // Note that the model must exist in the model path,
+    // otherwise the test fails.
     async fn test_axum_transcriptions() {
         init_settings_for_test().await;
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+edgen==0.1.2
+Levenshtein==0.24.0

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,15 +1,21 @@
 #!/bin/bash -i
 # ubuntu does not source .bashrc in (non-interactive) scripts
 
-# run all tests
+# run all tests:
 # starts the edgen server
 # runs tests with pytest
 # stops the server
 
+echo "================================================"
+date
+cargo run version
+echo "================================================"
+
 cargo run serve --nogui & > tests/tests.log 2>&1
 PID=$!
 
-python --version
+sleep 1
+
 python -m pytest tests
 
 kill -2 $PID

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,5 +1,6 @@
 
 from pathlib import Path
+import Levenshtein
 
 from edgen import Edgen, APIConnectionError
 import pytest
@@ -27,7 +28,12 @@ def test_transcriptions():
     print(expected)
 
     assert(type(transcription) is str)
-    assert(transcription == expected)
+
+    d = Levenshtein.distance(transcription, expected)
+    similarity = 100 - ((d / len(expected)) * 100)
+    print(f"distance: {d} of '{transcription}', similarity: {similarity}")
+
+    assert(similarity > 90.0)
 
 if __name__ == "__main__":
    test_transcriptions()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -14,8 +14,7 @@ def test_version():
     except APIConnectionError:
         pytest.fail("No connection. Is edgen running?")
 
-    # print(version)
-    # print(f"{expected} == {format_version(version)}")   
+    print(f"{expected} == {format_version(version)}")
 
     assert(type(version) is Version)
     assert(format_version(version) == expected)


### PR DESCRIPTION
We updated the audio/transcriptions default model to a smaller, less performant one. This change makes the corresponding unit test fail.
Therefore, I propose making it more flexible: pass if text generated is at least 90% similar to expected test.