### PR TITLE
Fix/issue1

### DIFF
--- a/crates/edgen_rt_llama_cpp/src/lib.rs
+++ b/crates/edgen_rt_llama_cpp/src/lib.rs
@@ -26,7 +26,6 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio::time::{interval, MissedTickBehavior};
 use tokio::{select, spawn};
-use tokio::runtime::{Handle, Runtime};
 use tracing::{error, info};
 
 use edgen_core::llm::{
@@ -123,15 +122,6 @@ impl LLMEndpoint for LlamaCppEndpoint {
 impl Default for LlamaCppEndpoint {
     fn default() -> Self {
         let models: Arc<DashMap<String, UnloadingModel>> = Default::default();
-
-        let (handle, _rt) = match Handle::try_current() {
-            Ok(h) => (h, None),
-            Err(_) => {
-                let rt = Runtime::new().unwrap();
-                (rt.handle().clone(), Some(rt))
-            },
-        };
-        let _guard = handle.enter();
         let models_clone = models.clone();
         let cleanup_thread = spawn(async move {
             let mut interval = interval(cleanup_interval());

--- a/crates/edgen_server/src/lib.rs
+++ b/crates/edgen_server/src/lib.rs
@@ -258,6 +258,8 @@ async fn run_server(args: &cli::Serve) -> bool {
     let flag_clone = reset_flag.clone();
 
     let _callback_handle = SETTINGS.read().await.add_change_callback(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
         flag_clone.store(true, Ordering::SeqCst);
         reset_channels.clear();
         block_on(crate::llm::reset_environment());


### PR DESCRIPTION
The problem is that the LlamaCppEndpoint is initialised without tokio runtime context when the updater triggers environment reset.
The solution is to create a runtime in the callback that triggers the reset.