### PR TITLE
[fix/issue33] main thread unwraps on intitialising settings without config dir

### DIFF
--- a/crates/edgen_server/src/lib.rs
+++ b/crates/edgen_server/src/lib.rs
@@ -122,7 +122,10 @@ pub fn config_reset() -> EdgenResult {
         std::fs::remove_file(&path).unwrap();
     }
 
-    settings::create_default_config_file().unwrap();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        settings::create_default_config_file().unwrap();
+    });
 
     Ok(())
 }

--- a/crates/edgen_server/src/status.rs
+++ b/crates/edgen_server/src/status.rs
@@ -321,7 +321,7 @@ async fn observe_progress(
 
 async fn have_tempdir(idx: usize, tmp: &PathBuf) -> bool {
     if !tmp.exists() {
-        let r = std::fs::create_dir(tmp);
+        let r = std::fs::create_dir_all(tmp);
         if r.is_err() {
             error!(
                 "progress observer: cannot create tmp directory ({:?}). Giving up",


### PR DESCRIPTION
when removing ~/.config/edgen the main thread unwraps. This was caused by a function creating a new runtime when it shouldn't.