### PR TITLE
Chore/issue122: add embeddings to settings integration tests

### DIFF
--- a/crates/edgen_core/src/settings.rs
+++ b/crates/edgen_core/src/settings.rs
@@ -62,6 +62,16 @@ pub async fn create_project_dirs() -> Result<(), std::io::Error> {
 
     let audio_transcriptions_dir = PathBuf::from(&audio_transcriptions_str);
 
+    let embeddings_str = SETTINGS
+        .read()
+        .await
+        .read()
+        .await
+        .embeddings_models_dir
+        .to_string();
+
+    let embeddings_dir = PathBuf::from(&embeddings_str);
+
     if !config_dir.is_dir() {
         std::fs::create_dir_all(config_dir)?;
     }
@@ -72,6 +82,10 @@ pub async fn create_project_dirs() -> Result<(), std::io::Error> {
 
     if !audio_transcriptions_dir.is_dir() {
         std::fs::create_dir_all(&audio_transcriptions_dir)?;
+    }
+
+    if !embeddings_dir.is_dir() {
+        std::fs::create_dir_all(&embeddings_str)?;
     }
 
     Ok(())

--- a/crates/edgen_server/src/status.rs
+++ b/crates/edgen_server/src/status.rs
@@ -316,8 +316,8 @@ async fn observe_progress(
         let mut m = tokio::fs::metadata(&f.path()).await;
         let mut last_size = 0;
         let mut timestamp = Instant::now();
-        while m.is_ok() {
-            let s = m.unwrap().len() as u64;
+        while let Ok(d) = m {
+            let s = d.len() as u64;
             let p = (s * 100) / size;
 
             if s > last_size {


### PR DESCRIPTION
The test passes but uses a small llm model instead of an embedding model.
TODO: use an appropriate embedding model.